### PR TITLE
Change the prompt message for clarity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Compiled binary versions of jira-terminal are uploaded to GitHub when a release 
 
 ## Usage
 When running the application for first time, you will be asked with following values.
-- namespace [This will be used to identify the namespace to be used.]
+- hostname [This will be used to identify the jira hostname to be used.]
 - email [Email address you use to login with the application.]
 - token [You can obtain the app password from the link specified in the application]
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -50,7 +50,7 @@ fn create_config() {
     let mut email = String::new();
     println!("Welcome to JIRA Terminal.");
     println!("Since this is your first run, we will ask you a few questions. ");
-    println!("Please enter your URL of JIRA. (Example: example.atlassian.net): ");
+    println!("Please enter your hostname of JIRA. (Example: example.atlassian.net): ");
     io::stdin()
         .read_line(&mut namespace)
         .expect("Failed to read input.");


### PR DESCRIPTION
The hostname will be displayed instead of URL.
Closes #5 