### PR TITLE
Handle error better with exit code and stderr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "jira-terminal"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jira-terminal"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["Amrit Ghimire <iamritghimire@gmail.com>"]
 edition = "2018"
 description = "This is a command line application that can be used as a personal productivity tool for interacting with JIRA"

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -13,10 +13,10 @@ fn handle_response_error_json(
             let response_string = r.into_string()?;
             match json::parse(&response_string) {
                 Ok(j) => {
-                    println!("{}", json::stringify_pretty(j, 4));
+                    eprintln!("{}", json::stringify_pretty(j, 4));
                 }
                 Err(_) => {
-                    println!("{}", response_string);
+                    eprintln!("{}", response_string);
                 }
             }
             Err(ureq::Error::Status(
@@ -41,10 +41,10 @@ fn handle_response_error(
             let response_string = r.into_string()?;
             match json::parse(&response_string) {
                 Ok(j) => {
-                    println!("{}", json::stringify_pretty(j, 4));
+                    eprintln!("{}", json::stringify_pretty(j, 4));
                 }
                 Err(_) => {
-                    println!("{}", response_string);
+                    eprintln!("{}", response_string);
                 }
             }
             Err(ureq::Error::Status(

--- a/src/jira/assign.rs
+++ b/src/jira/assign.rs
@@ -9,8 +9,8 @@ pub fn assign_task(ticket: String, user: String) {
     };
     let update_response = api::put_call(format!("issue/{}/assignee", ticket), payload, 3);
     if update_response.is_err() {
-        println!("Error occured in API Call: {:?}", update_response);
-        return;
+        eprintln!("Error occured While assigning the ticket.");
+        std::process::exit(1);
     }
     let response = update_response.unwrap();
     println!("Successfully Assigned {}", response);

--- a/src/jira/comments.rs
+++ b/src/jira/comments.rs
@@ -67,8 +67,8 @@ pub fn display_comment_list(comments: &json::JsonValue) {
 pub fn get_all_comments(ticket: String) {
     let comments_response = api::get_call_v2(format!("issue/{}/comment", ticket));
     if comments_response.is_err() {
-        println!("Cannot fetch the comments.");
-        return;
+        eprintln!("Cannot fetch the comments.");
+        std::process::exit(1);
     }
     display_comment_list(&comments_response.unwrap());
 }
@@ -94,8 +94,8 @@ pub fn add_new_comment(ticket: String, matches: &ArgMatches) {
     };
     let update_response = api::post_call(format!("issue/{}/comment", ticket), payload, 2);
     if update_response.is_err() {
-        println!("Error occured in API Call: {:?}", update_response);
-        return;
+        eprintln!("Error occured while adding comment.");
+        std::process::exit(1);
     }
     let response = json::parse(&update_response.unwrap());
     println!("Successfully Added a new comment");

--- a/src/jira/details.rs
+++ b/src/jira/details.rs
@@ -62,9 +62,8 @@ pub fn show_details(ticket: String, fields: String) {
     };
     let details_response = api::get_call_v2(format!("issue/{}", ticket));
     if details_response.is_err() {
-        println!("Error occured when searching tickets. ");
-        println!("{:?}", details_response);
-        return;
+        eprintln!("Error occured when searching tickets. ");
+        std::process::exit(1);
     }
 
     let fields_list = fields_expanded.trim().split(',');

--- a/src/jira/fields.rs
+++ b/src/jira/fields.rs
@@ -3,13 +3,13 @@ use crate::jira::api;
 pub fn display_all_fields(ticket: String) {
     let fields_response = api::get_call_v2(format!("issue/{}/editmeta", ticket));
     if fields_response.is_err() {
-        println!("Error occured in API Call: {:?}", fields_response);
-        return;
+        eprintln!("Error occured in API Call: {:?}", fields_response);
+        std::process::exit(1);
     }
     let fields = &fields_response.unwrap()["fields"];
     if fields.is_null() {
-        println!("Cannot fetch fields");
-        return;
+        eprintln!("Cannot fetch fields");
+        std::process::exit(1);
     }
     println!("{:35}: Field Header", "Key");
     println!("{:-<65}", "-");

--- a/src/jira/lists.rs
+++ b/src/jira/lists.rs
@@ -86,9 +86,8 @@ pub fn list_issues(matches: &ArgMatches) {
     let jql = form_jql(matches);
     let search_response = api::get_call_v3(format!("search?jql={}", jql));
     if search_response.is_err() {
-        println!("Error occured when searching tickets. ");
-        println!("{:?}", search_response);
-        return;
+        eprintln!("Error occured when searching tickets. ");
+        std::process::exit(1);
     }
     if matches.is_present("alias") {
         let alias_name = matches.value_of("alias").unwrap();
@@ -102,7 +101,7 @@ pub fn list_issues(matches: &ArgMatches) {
     let issues = &search_response.unwrap()["issues"];
     if !issues.is_array() {
         println!("No issues found for the filter.");
-        return;
+        std::process::exit(0);
     }
     let display: String = String::from(
         matches
@@ -128,7 +127,7 @@ pub fn list_issues(matches: &ArgMatches) {
     for header in headers.clone() {
         if display_options[header].is_null() {
             eprintln!("Unknown display option {} passed. ", header);
-            return;
+            std::process::exit(1);
         }
         display_header(&display_options[header]);
         total = total + display_options[header]["width"].as_usize().unwrap_or(0) + 1;

--- a/src/jira/mod.rs
+++ b/src/jira/mod.rs
@@ -49,7 +49,7 @@ pub fn handle_update_matches(matches: &ArgMatches) {
 }
 
 pub fn handle_new_matches(matches: &ArgMatches) {
-    new_issue::handle_issue_creation(&matches);
+    new_issue::handle_issue_creation(matches);
 }
 
 pub fn handle_assign_matches(matches: &ArgMatches) {

--- a/src/jira/new_issue.rs
+++ b/src/jira/new_issue.rs
@@ -108,14 +108,14 @@ pub fn handle_issue_creation(matches: &ArgMatches) {
         let split = main.split_once("-");
         if split.is_none() {
             eprintln!("Invalid ticket id passed as main option.");
-            return;
+            std::process::exit(1);
         }
         project = split.unwrap().0.to_string();
         parent = Some(main.to_string());
     }
     if project.is_empty() {
         eprintln!("Cannot determine project. ");
-        return;
+        std::process::exit(1);
     }
     let summary = get_or_ask(
         &matches,
@@ -123,8 +123,8 @@ pub fn handle_issue_creation(matches: &ArgMatches) {
         "Please enter the summary of the project: ",
     );
     if summary.is_none() {
-        println!("Summary is a required field.");
-        return;
+        eprintln!("Summary is a required field.");
+        std::process::exit(1);
     }
     let mut description = matches.value_of("description").unwrap_or("").to_string();
     if !matches.is_present("quiet") && description.is_empty() {
@@ -148,8 +148,8 @@ pub fn handle_issue_creation(matches: &ArgMatches) {
         config::get_config("account_id".to_string())
     };
     if assignee.is_empty() {
-        println!("Please provide appropriate user email to continue.");
-        return;
+        eprintln!("Please provide appropriate user email to continue.");
+        std::process::exit(1);
     }
     let issuetype = get_or_ask(matches, "type", "Please enter type of issue: ");
     let labels = get_or_ask(
@@ -191,7 +191,8 @@ pub fn handle_issue_creation(matches: &ArgMatches) {
     let json_node = payload.json();
     let created_api_response = api::post_call("issue".to_string(), json_node, 2);
     if created_api_response.is_err() {
-        eprintln!("Unable to create ticket. {:?}", created_api_response);
+        eprintln!("Unable to create ticket.");
+        std::process::exit(1);
     }
     let response = json::parse(&created_api_response.unwrap());
     if let Ok(response_object) = response {

--- a/src/jira/new_issue.rs
+++ b/src/jira/new_issue.rs
@@ -118,7 +118,7 @@ pub fn handle_issue_creation(matches: &ArgMatches) {
         std::process::exit(1);
     }
     let summary = get_or_ask(
-        &matches,
+        matches,
         "summary",
         "Please enter the summary of the project: ",
     );

--- a/src/jira/transitions.rs
+++ b/src/jira/transitions.rs
@@ -91,8 +91,8 @@ pub fn get_transition_code(ticket: String, transition_name: String) -> Option<u1
 pub fn print_transition_lists(ticket: String) {
     let transition_object_response = get_transitions(ticket.clone());
     if transition_object_response.is_none() {
-        println!("Cannot find transitions for {}", ticket);
-        return;
+        eprintln!("Cannot find transitions for {}", ticket);
+        std::process::exit(1);
     }
     let transitions = transition_object_response.unwrap();
     println!("Allowed transitions for {} are as below: ", ticket);
@@ -117,8 +117,8 @@ pub fn print_transition_lists(ticket: String) {
 pub fn move_ticket_status(ticket: String, status: String) {
     let transition_options = get_transition_code(ticket.clone(), status);
     if transition_options.is_none() {
-        println!("Invalid status...");
-        return;
+        eprintln!("Invalid status...");
+        std::process::exit(1);
     }
     let transition_code = transition_options.unwrap();
     let json_object = json::object! {
@@ -129,8 +129,8 @@ pub fn move_ticket_status(ticket: String, status: String) {
     let transitions_response =
         api::post_call(format!("issue/{}/transitions", ticket), json_object, 3);
     if transitions_response.is_err() {
-        println!("Unable to perform transition. {:?}", transitions_response);
-        return;
+        eprintln!("Unable to perform transition.");
+        std::process::exit(1);
     }
     let response = transitions_response.unwrap();
     println!("Successfully Completed {}", response);

--- a/src/jira/update.rs
+++ b/src/jira/update.rs
@@ -19,7 +19,7 @@ fn get_object_by_name(list: &json::JsonValue, name: String) -> Option<json::Json
 fn get_object_lists_from_value(list: &json::JsonValue, value: String) -> Vec<json::JsonValue> {
     let mut selected_entries: Vec<json::JsonValue> = vec![];
     for name in value.split(',') {
-        let object = get_object_by_name(&list, config::get_alias_or(name.to_string()));
+        let object = get_object_by_name(list, config::get_alias_or(name.to_string()));
         if let Some(entry) = object {
             selected_entries.push(entry);
         }

--- a/src/jira/update.rs
+++ b/src/jira/update.rs
@@ -32,22 +32,22 @@ pub fn update_jira_ticket(ticket: String, key: String, entry: String) {
     let update_key = config::get_alias_or(key);
     let fields_response = api::get_call_v2(format!("issue/{}/editmeta", ticket));
     if fields_response.is_err() {
-        println!("Error occured in API Call: {:?}", fields_response);
-        return;
+        eprintln!("Error occured while updating the ticket.");
+        std::process::exit(1);
     }
     let fields = &fields_response.unwrap()["fields"][update_key.clone()];
     let mut update_json = json::object! {};
     if fields.is_null() {
-        println!("Cannot fetch fields");
-        return;
+        eprintln!("Cannot fetch fields");
+        std::process::exit(1);
     }
     if !fields["autoCompleteUrl"].is_null() {
-        println!("Cannot update provided key.");
-        return;
+        eprintln!("Cannot update provided key.");
+        std::process::exit(1);
     }
     if update_key == "comment" || update_key == "assignee" {
-        println!("Comment and assignee has their own section. Please check help for details.");
-        return;
+        eprintln!("Comment and assignee has their own section. Please check help for details.");
+        std::process::exit(1);
     }
 
     if fields["allowedValues"].is_array() {
@@ -70,8 +70,8 @@ pub fn update_jira_ticket(ticket: String, key: String, entry: String) {
     };
     let update_response = api::put_call(format!("issue/{}", ticket), payload, 3);
     if update_response.is_err() {
-        println!("Error occured in API Call: {:?}", update_response);
-        return;
+        eprintln!("Error occured while updating the ticket");
+        std::process::exit(1);
     }
     let response = update_response.unwrap();
     println!("Successfully Updated {}", response);

--- a/src/subcommands/mod.rs
+++ b/src/subcommands/mod.rs
@@ -51,7 +51,8 @@ pub fn handle_matches(mut app: App) {
         if shell_parse.is_err() {
             eprintln!(
                 "Invalid shell name passed. Only bash, fish, zsh, powershell, elvish are allowed."
-            )
+            );
+            std::process::exit(1);
         }
         let shell = shell_parse.unwrap();
         app.gen_completions_to("jira-terminal", shell, &mut io::stdout());


### PR DESCRIPTION
    A non-zero exit code is reported when jira-terminal exits with an error
    Error messages are printed on STDERR instead of STDOUT

Closes #17