### PR TITLE
Handle updates to fields that expect numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "jira-terminal"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jira-terminal"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Amrit Ghimire <iamritghimire@gmail.com>"]
 edition = "2018"
 description = "This is a command line application that can be used as a personal productivity tool for interacting with JIRA"

--- a/src/jira/update.rs
+++ b/src/jira/update.rs
@@ -61,6 +61,14 @@ pub fn update_jira_ticket(ticket: String, key: String, entry: String) {
     } else if fields["schema"]["type"] == "array" {
         let values: Vec<&str> = value.split(',').collect();
         update_json[update_key] = values.into();
+    } else if fields["schema"]["type"] == "number" {
+        match value.parse::<f64>() {
+            Ok(number) => update_json[update_key] = number.into(),
+            Err(_) => {
+                eprintln!("Cannot parse value as a number.");
+                std::process::exit(1);
+            }
+        }
     } else {
         update_json[update_key] = value.into();
     }


### PR DESCRIPTION
Some fields (e.g., story points) require the value to be a number.

This PR checks if a field schema has a type 'number' and if it does attempts to parse the value as a number.