### PR TITLE
feat: added logout command

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ SUBCOMMANDS:
     new               Create a new ticket.
     transition        Transition of ticket across status.
     update            Update a field for a ticket
+    logout            Erase configuration and log out of Jira
 ```
 
 ### List of Tickets

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -20,7 +20,7 @@ pub fn str_cap(s: String) -> String {
 /// ```
 /// assert!(get_config_file_name(), "/home/user/.jira_terminal_configuration.json".to_string());
 /// ```
-fn get_config_file_name() -> String {
+pub fn get_config_file_name() -> String {
     let config_file_name: String = String::from(".jira_terminal_configuration.json");
     match home::home_dir() {
         Some(path) => format!("{}/{}", path.display(), config_file_name),

--- a/src/jira/logout.rs
+++ b/src/jira/logout.rs
@@ -1,0 +1,9 @@
+use std::path::Path;
+
+use crate::config::get_config_file_name;
+
+pub fn delete_configuration(){
+    let conf_fn = get_config_file_name();
+    let path = Path::new(&conf_fn);
+    std::fs::remove_file(&path).unwrap(); // user will be prompted for login
+}

--- a/src/jira/logout.rs
+++ b/src/jira/logout.rs
@@ -6,4 +6,5 @@ pub fn delete_configuration(){
     let conf_fn = get_config_file_name();
     let path = Path::new(&conf_fn);
     std::fs::remove_file(&path).unwrap(); // user will be prompted for login
+    println!("You've logged out successfully, please keep your jira token handy for next time")
 }

--- a/src/jira/mod.rs
+++ b/src/jira/mod.rs
@@ -3,6 +3,7 @@ mod assign;
 pub mod comments;
 pub mod details;
 mod fields;
+mod logout;
 pub mod lists;
 mod new_issue;
 pub mod transitions;
@@ -20,6 +21,10 @@ pub fn handle_transition_matches(matches: &ArgMatches) {
         let status = matches.value_of("STATUS").unwrap();
         transitions::move_ticket_status(ticket.to_string(), status.to_string());
     }
+}
+
+pub fn handle_logout(_matches: &ArgMatches) {
+    logout::delete_configuration();
 }
 
 pub fn handle_fields_matches(matches: &ArgMatches) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,8 @@ fn main() {
         .subcommand(subcommands::comments::subcommand())
         .subcommand(subcommands::update::subcommand())
         .subcommand(subcommands::autocompletion::subcommand())
-        .subcommand(subcommands::new_subcommand::subcommand());
+        .subcommand(subcommands::new_subcommand::subcommand())
+        .subcommand(subcommands::logout::subcommand());
 
     subcommands::handle_matches(app);
 }

--- a/src/subcommands/logout.rs
+++ b/src/subcommands/logout.rs
@@ -1,0 +1,6 @@
+use clap::{App, SubCommand};
+
+pub fn subcommand() -> App<'static, 'static> {
+    SubCommand::with_name("logout")
+        .about("Erase configuration and log out of Jira")
+}

--- a/src/subcommands/mod.rs
+++ b/src/subcommands/mod.rs
@@ -4,6 +4,7 @@ pub mod autocompletion;
 pub mod comments;
 pub mod detail;
 pub mod fields;
+pub mod logout;
 pub mod list;
 pub mod new_subcommand;
 pub mod transition;
@@ -37,6 +38,8 @@ pub fn handle_matches(mut app: App) {
         jira::handle_detail_matches(details);
     } else if let Some(fields) = matches.subcommand_matches("fields") {
         jira::handle_fields_matches(fields);
+    } else if let Some(fields) = matches.subcommand_matches("logout") {
+        jira::handle_logout(fields);
     } else if let Some(updates) = matches.subcommand_matches("update") {
         jira::handle_update_matches(updates);
     } else if let Some(new_matches) = matches.subcommand_matches("new") {


### PR DESCRIPTION
Added logout command

```bash
(base) jira-terminal git:feat_logout ❯ cargo run -- logout                               ✹
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/jira-terminal logout`
You've logged out successfully, please keep your jira token handy for next time
(base) jira-terminal git:feat_logout ❯ cargo run -- list                                 ✹
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/jira-terminal list`
Welcome to JIRA Terminal.
Since this is your first run, we will ask you a few questions.
```